### PR TITLE
Fixed time zone issues with getting energy summaries

### DIFF
--- a/core/src/main/java/com/amcglynn/myzappi/core/service/ZappiService.java
+++ b/core/src/main/java/com/amcglynn/myzappi/core/service/ZappiService.java
@@ -87,8 +87,27 @@ public class ZappiService {
         client.stopBoost();
     }
 
+    /**
+     * Get energy usage for a date. Note that this will return the values for the day in UTC.
+     * @param localDate specific date to retrieve energy usage
+     * @return summary of energy usage for the day
+     */
     public ZappiDaySummary getEnergyUsage(LocalDate localDate) {
         return new ZappiDaySummary(client.getZappiHistory(localDate).getReadings());
+    }
+
+    /**
+     * Return a time-zone adjusted energy usage for a date. This will return readings in UTC but they will be adjusted
+     * by an offset.
+     * @param localDate specific date to retrieve energy usage
+     * @param userZone time zone of the consumer.
+     * @return summary of energy usage for the day
+     */
+    public ZappiDaySummary getEnergyUsage(LocalDate localDate, ZoneId userZone) {
+        var utcTime = LocalTime.of(0, 0);   // start from 0:00AM local time for the user and then convert that to UTC for the API
+        var userTime = utcTime.atDate(localDate).atZone(userZone)
+                .withZoneSameInstant(ZoneId.of("UTC"));
+        return new ZappiDaySummary(client.getZappiHistory(userTime.toLocalDate(), userTime.toLocalTime().getHour()).getReadings());
     }
 
     private LocalTime roundToNearest15Mins(Duration duration) {

--- a/login-lambda/src/main/java/com/amcglynn/myzappi/login/SessionManagementService.java
+++ b/login-lambda/src/main/java/com/amcglynn/myzappi/login/SessionManagementService.java
@@ -7,7 +7,6 @@ import com.amcglynn.myzappi.core.service.EncryptionService;
 
 import java.net.HttpCookie;
 import java.time.Instant;
-import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -39,7 +38,6 @@ public class SessionManagementService {
         var session = getSession(input);
 
         if (session.isPresent()) {
-            System.out.println("Found session with sessionID = " + session.get().getSessionId());
             return session;
         }
 
@@ -49,7 +47,6 @@ public class SessionManagementService {
             var newSession = session.get();
             sessionRepository.write(newSession);
 
-            System.out.println("Creating cookie with sessionID = " + newSession.getSessionId());
             var responseHeaders = new HashMap<>(response.getHeaders());
             responseHeaders.put("Set-Cookie", "sessionID=" + newSession.getSessionId() + "; Max-Age=" + newSession.getTtl() + "; Path=/; Secure; HttpOnly");
             response.setHeaders(responseHeaders);

--- a/login-with-amazon/src/main/java/com/amcglynn/lwa/LwaClient.java
+++ b/login-with-amazon/src/main/java/com/amcglynn/lwa/LwaClient.java
@@ -50,7 +50,6 @@ public class LwaClient {
 
     public Optional<String> getTimeZone(String baseUrl, String deviceId, String accessToken) {
         var url = baseUrl + "/v2/devices/" + deviceId + "/settings/System.timeZone";
-        System.out.println("Making request to " + url);
         var request = new Request.Builder()
                 .addHeader("Authorization", "Bearer " + accessToken)
                 .url(url)

--- a/myenergi-client/src/main/java/com/amcglynn/myenergi/MockMyEnergiClient.java
+++ b/myenergi-client/src/main/java/com/amcglynn/myenergi/MockMyEnergiClient.java
@@ -93,4 +93,13 @@ public class MockMyEnergiClient extends MyEnergiClient {
         mockWebServer.enqueue(mockResponse);
         return super.getZappiHistory(localDate);
     }
+
+    @Override
+    public ZappiDayHistory getZappiHistory(LocalDate localDate, int offset) {
+        var mockResponse = new MockResponse()
+                .setResponseCode(200)
+                .setBody(ZappiResponse.getHistoryResponse());
+        mockWebServer.enqueue(mockResponse);
+        return super.getZappiHistory(localDate, offset);
+    }
 }

--- a/myenergi-client/src/main/java/com/amcglynn/myenergi/MyEnergiClient.java
+++ b/myenergi-client/src/main/java/com/amcglynn/myenergi/MyEnergiClient.java
@@ -161,6 +161,21 @@ public class MyEnergiClient {
         }
     }
 
+    public ZappiDayHistory getZappiHistory(LocalDate localDate, int offset) {
+        if (offset < 0) {
+            throw new IllegalArgumentException("offset must be positive");
+        }
+        String endPointUrl = "/cgi-jday-Z" + serialNumber + "-" + localDate.getYear() +
+                "-" + localDate.getMonthValue() + "-" + localDate.getDayOfMonth() + "-" + offset;
+        var response = getRequest(endPointUrl);
+
+        try {
+            return new ObjectMapper().readValue(response, new TypeReference<>(){});
+        } catch (JsonProcessingException e) {
+            throw new InvalidResponseFormatException();
+        }
+    }
+
     private String getRequest(String endPointUrl) {
         try {
             var request = new Request.Builder()

--- a/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/MyZappiSkillStreamHandler.java
+++ b/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/MyZappiSkillStreamHandler.java
@@ -36,7 +36,7 @@ public class MyZappiSkillStreamHandler extends SkillStreamHandler {
                 .addRequestHandler(new StartBoostHandler(serviceManager.getZappiServiceBuilder(), userIdResolverFactory, userZoneResolver))
                 .addRequestHandler(new StopBoostHandler(serviceManager.getZappiServiceBuilder(), userIdResolverFactory))
                 .addRequestHandler(new GetPlugStatusHandler(serviceManager.getZappiServiceBuilder(), userIdResolverFactory))
-                .addRequestHandler(new GetEnergyUsageHandler(serviceManager.getZappiServiceBuilder(), userIdResolverFactory))
+                .addRequestHandler(new GetEnergyUsageHandler(serviceManager.getZappiServiceBuilder(), userIdResolverFactory, userZoneResolver))
                 .addRequestHandler(new SetChargeModeHandler(serviceManager.getZappiServiceBuilder(), userIdResolverFactory))
                 .addRequestHandler(new GoGreenHandler(serviceManager.getZappiServiceBuilder(), userIdResolverFactory))
                 .addRequestHandler(new ChargeMyCarHandler(serviceManager.getZappiServiceBuilder(), userIdResolverFactory))

--- a/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/responses/ZappiDaySummaryCardResponse.java
+++ b/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/responses/ZappiDaySummaryCardResponse.java
@@ -11,9 +11,6 @@ public class ZappiDaySummaryCardResponse {
         response += "Consumed: " + summary.getConsumed() + "kWh\n";
         response += "Solar generated: " + summary.getSolarGeneration() + "kWh\n";
         response += "Charged: " + summary.getEvSummary().getTotal() + "kWh\n";
-        if (summary.getSampleSize() < 1440) {
-            response += "Note that there are missing data points so this reading is not completely accurate.";
-        }
     }
 
     @Override

--- a/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/responses/ZappiDaySummaryVoiceResponse.java
+++ b/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/responses/ZappiDaySummaryVoiceResponse.java
@@ -11,10 +11,6 @@ public class ZappiDaySummaryVoiceResponse {
         response += "Consumed " + summary.getConsumed() + " kilowatt hours. ";
         response += "Solar generation was " + summary.getSolarGeneration() + " kilowatt hours. ";
         response += "Charged " + summary.getEvSummary().getTotal() + " kilowatt hours to your E.V. ";
-        if (summary.getSampleSize() < 1440) {
-            // extra dot added intentionally here to control the speed at which Alexa says this.
-            response += ". Note that there are missing data points so this reading is not completely accurate. ";
-        }
     }
 
     @Override


### PR DESCRIPTION
myenergi status APIs work in UTC. The My Zappi lambda also has a UTC clock but when Alexa requests the status, it is in local time. There was a mismatch which happened when DST happened in Ireland. 

The fix for this involves looking up the user's time zone and adjusts the requested date to UTC date and time (hour offset) passed to the myenergi API. The myenergi API supports a start time for a certain day and will offset the number of readings by that amount.