### PR TITLE
Multithreaded status summary

### DIFF
--- a/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/MyZappiSkillStreamHandler.java
+++ b/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/MyZappiSkillStreamHandler.java
@@ -79,7 +79,7 @@ public class MyZappiSkillStreamHandler extends SkillStreamHandler {
                 .addRequestHandler(new GetChargeRateHandler())
                 .addRequestHandler(new ChargeMyCarHandler())
                 .addRequestHandler(new GetEnergyCostHandler(serviceManager.getTariffService()))
-                .addRequestHandler(new SetChargeModeHandler(serviceManager.getExecutorService()))
+                .addRequestHandler(new SetChargeModeHandler())
                 .addRequestHandler(new SetEddiModeToNormalHandler(serviceManager.getMyEnergiServiceBuilder(), userIdResolverFactory))
                 .addRequestHandler(new SetEddiModeToStoppedHandler(serviceManager.getMyEnergiServiceBuilder(), userIdResolverFactory))
                 .addRequestHandler(new BoostEddiHandler(serviceManager.getMyEnergiServiceBuilder(), userIdResolverFactory))

--- a/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/RequestAttributes.java
+++ b/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/RequestAttributes.java
@@ -1,10 +1,15 @@
 package com.amcglynn.myzappi;
 
 import com.amazon.ask.dispatcher.request.handler.HandlerInput;
+import com.amcglynn.myenergi.ZappiStatusSummary;
 import com.amcglynn.myzappi.core.exception.MissingDeviceException;
 import com.amcglynn.myzappi.core.service.ZappiService;
 
 import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 public class RequestAttributes {
     private RequestAttributes() {
@@ -18,6 +23,15 @@ public class RequestAttributes {
     public static String getUserId(HandlerInput handlerInput) {
         var requestAttributes = handlerInput.getAttributesManager().getRequestAttributes();
         return (String) requestAttributes.get("userId");
+    }
+
+    public static Future<List<ZappiStatusSummary>> getZappiStatusSummary(HandlerInput handlerInput) {
+        var requestAttributes = handlerInput.getAttributesManager().getRequestAttributes();
+        return (Future<List<ZappiStatusSummary>>) requestAttributes.get("zappiStatusSummary");
+    }
+
+    public static ZappiStatusSummary waitForZappiStatusSummary(HandlerInput handlerInput) throws ExecutionException, InterruptedException {
+        return getZappiStatusSummary(handlerInput).get().get(0);
     }
 
     public static ZappiService getZappiServiceOrThrow(HandlerInput handlerInput) {

--- a/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/GetChargeModeHandler.java
+++ b/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/GetChargeModeHandler.java
@@ -4,6 +4,7 @@ import com.amazon.ask.dispatcher.request.handler.HandlerInput;
 import com.amazon.ask.dispatcher.request.handler.RequestHandler;
 import com.amazon.ask.model.Response;
 import com.amcglynn.myzappi.core.Brand;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
@@ -12,7 +13,7 @@ import java.util.Optional;
 import static com.amazon.ask.request.Predicates.intentName;
 import static com.amcglynn.myzappi.LocalisedResponse.cardResponse;
 import static com.amcglynn.myzappi.LocalisedResponse.voiceResponse;
-import static com.amcglynn.myzappi.RequestAttributes.getZappiServiceOrThrow;
+import static com.amcglynn.myzappi.RequestAttributes.waitForZappiStatusSummary;
 
 @Slf4j
 public class GetChargeModeHandler implements RequestHandler {
@@ -22,9 +23,10 @@ public class GetChargeModeHandler implements RequestHandler {
         return handlerInput.matches(intentName("GetChargeMode"));
     }
 
+    @SneakyThrows
     @Override
     public Optional<Response> handle(HandlerInput handlerInput) {
-        var summary = getZappiServiceOrThrow(handlerInput).getStatusSummary().get(0);
+        var summary = waitForZappiStatusSummary(handlerInput);
 
         return handlerInput.getResponseBuilder()
                 .withSpeech(voiceResponse(handlerInput, "charge-mode", Map.of("chargeMode", summary.getChargeMode().getDisplayName())))

--- a/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/GetChargeRateHandler.java
+++ b/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/GetChargeRateHandler.java
@@ -6,13 +6,14 @@ import com.amazon.ask.model.Response;
 import com.amcglynn.myzappi.core.Brand;
 import com.amcglynn.myzappi.handlers.responses.GetChargeRateCardResponse;
 import com.amcglynn.myzappi.handlers.responses.GetChargeRateVoiceResponse;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Locale;
 import java.util.Optional;
 
 import static com.amazon.ask.request.Predicates.intentName;
-import static com.amcglynn.myzappi.RequestAttributes.getZappiServiceOrThrow;
+import static com.amcglynn.myzappi.RequestAttributes.waitForZappiStatusSummary;
 
 @Slf4j
 public class GetChargeRateHandler implements RequestHandler {
@@ -22,11 +23,12 @@ public class GetChargeRateHandler implements RequestHandler {
         return handlerInput.matches(intentName("GetChargeRate"));
     }
 
+    @SneakyThrows
     @Override
     public Optional<Response> handle(HandlerInput handlerInput) {
         var locale = Locale.forLanguageTag(handlerInput.getRequestEnvelope().getRequest().getLocale());
 
-        var summary = getZappiServiceOrThrow(handlerInput).getStatusSummary().get(0);
+        var summary = waitForZappiStatusSummary(handlerInput);
 
         return handlerInput.getResponseBuilder()
                 .withSpeech(new GetChargeRateVoiceResponse(locale, summary).toString())

--- a/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/GetPlugStatusHandler.java
+++ b/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/GetPlugStatusHandler.java
@@ -7,12 +7,13 @@ import com.amcglynn.myenergi.EvStatusSummary;
 import com.amcglynn.myzappi.core.Brand;
 import com.amcglynn.myzappi.handlers.responses.ZappiEvConnectionStatusCardResponse;
 import com.amcglynn.myzappi.handlers.responses.ZappiEvConnectionStatusVoiceResponse;
+import lombok.SneakyThrows;
 
 import java.util.Locale;
 import java.util.Optional;
 
 import static com.amazon.ask.request.Predicates.intentName;
-import static com.amcglynn.myzappi.RequestAttributes.getZappiServiceOrThrow;
+import static com.amcglynn.myzappi.RequestAttributes.waitForZappiStatusSummary;
 
 public class GetPlugStatusHandler implements RequestHandler {
 
@@ -21,10 +22,10 @@ public class GetPlugStatusHandler implements RequestHandler {
         return handlerInput.matches(intentName("GetPlugStatus"));
     }
 
+    @SneakyThrows
     @Override
     public Optional<Response> handle(HandlerInput handlerInput) {
-        var zappiService = getZappiServiceOrThrow(handlerInput);
-        var summary = new EvStatusSummary(zappiService.getStatusSummary().get(0));
+        var summary = new EvStatusSummary(waitForZappiStatusSummary(handlerInput));
         var locale = Locale.forLanguageTag(handlerInput.getRequestEnvelope().getRequest().getLocale());
         return handlerInput.getResponseBuilder()
                 .withSpeech(new ZappiEvConnectionStatusVoiceResponse(locale, summary).toString())

--- a/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/SetChargeModeHandler.java
+++ b/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/SetChargeModeHandler.java
@@ -6,11 +6,8 @@ import com.amazon.ask.model.IntentRequest;
 import com.amazon.ask.model.Response;
 import com.amcglynn.myenergi.EvStatusSummary;
 import com.amcglynn.myenergi.ZappiChargeMode;
-import com.amcglynn.myzappi.UserIdResolverFactory;
 import com.amcglynn.myzappi.core.Brand;
-import com.amcglynn.myzappi.core.service.MyEnergiService;
 import com.amcglynn.myzappi.mappers.AlexaZappiChargeModeMapper;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
@@ -73,6 +70,7 @@ public class SetChargeModeHandler implements RequestHandler {
                 cardResponse += "\n" + cardResponse(handlerInput, "connect-ev");
             }
         } catch (ExecutionException | InterruptedException exception) {
+            // it's not important if we can't get the Zappi status, we can still change the charge mode to what the user requested
             log.info("Failed to get Zappi status when changing the charge mode, ignoring...", exception);
         }
 

--- a/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/StatusSummaryHandler.java
+++ b/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/StatusSummaryHandler.java
@@ -9,12 +9,14 @@ import com.amazon.ask.model.services.directive.SpeakDirective;
 import com.amcglynn.myzappi.core.Brand;
 import com.amcglynn.myzappi.handlers.responses.ZappiStatusSummaryCardResponse;
 import com.amcglynn.myzappi.handlers.responses.ZappiStatusSummaryVoiceResponse;
+import lombok.SneakyThrows;
 
 import java.util.Locale;
 import java.util.Optional;
 
 import static com.amazon.ask.request.Predicates.intentName;
 import static com.amcglynn.myzappi.RequestAttributes.getZappiServiceOrThrow;
+import static com.amcglynn.myzappi.RequestAttributes.waitForZappiStatusSummary;
 
 public class StatusSummaryHandler implements RequestHandler {
     @Override
@@ -22,6 +24,7 @@ public class StatusSummaryHandler implements RequestHandler {
         return handlerInput.matches(intentName("StatusSummary"));
     }
 
+    @SneakyThrows
     @Override
     public Optional<Response> handle(HandlerInput handlerInput) {
         handlerInput.getServiceClientFactory().getDirectiveService()
@@ -31,7 +34,7 @@ public class StatusSummaryHandler implements RequestHandler {
                         .build());
         var locale = Locale.forLanguageTag(handlerInput.getRequestEnvelope().getRequest().getLocale());
 
-        var summary = getZappiServiceOrThrow(handlerInput).getStatusSummary().get(0);
+        var summary = waitForZappiStatusSummary(handlerInput);;
 
         return handlerInput.getResponseBuilder()
                 .withSpeech(new ZappiStatusSummaryVoiceResponse(locale, summary).toString())

--- a/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/StatusSummaryHandler.java
+++ b/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/StatusSummaryHandler.java
@@ -34,7 +34,7 @@ public class StatusSummaryHandler implements RequestHandler {
                         .build());
         var locale = Locale.forLanguageTag(handlerInput.getRequestEnvelope().getRequest().getLocale());
 
-        var summary = waitForZappiStatusSummary(handlerInput);;
+        var summary = waitForZappiStatusSummary(handlerInput);
 
         return handlerInput.getResponseBuilder()
                 .withSpeech(new ZappiStatusSummaryVoiceResponse(locale, summary).toString())

--- a/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/interceptors/ZappiServiceInjectorInterceptor.java
+++ b/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/interceptors/ZappiServiceInjectorInterceptor.java
@@ -4,18 +4,22 @@ import com.amazon.ask.dispatcher.request.handler.HandlerInput;
 import com.amazon.ask.dispatcher.request.interceptor.RequestInterceptor;
 import com.amcglynn.myzappi.UserIdResolverFactory;
 import com.amcglynn.myzappi.core.service.MyEnergiService;
-import com.amcglynn.myzappi.core.service.UserIdResolver;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @Slf4j
 public class ZappiServiceInjectorInterceptor implements RequestInterceptor {
 
     private final MyEnergiService.Builder myenergiServiceBuilder;
     private final UserIdResolverFactory userIdResolverFactory;
+    private final ExecutorService executorService;
 
     public ZappiServiceInjectorInterceptor(MyEnergiService.Builder myenergiServiceBuilder, UserIdResolverFactory userIdResolverFactory) {
         this.myenergiServiceBuilder = myenergiServiceBuilder;
         this.userIdResolverFactory = userIdResolverFactory;
+        this.executorService = Executors.newFixedThreadPool(1);
     }
 
     @Override
@@ -26,6 +30,9 @@ public class ZappiServiceInjectorInterceptor implements RequestInterceptor {
         requestAttributes.put("userId", userIdResolver.getUserId());
 
         var zappiService = myenergiServiceBuilder.build(userIdResolver).getZappiService();
-        zappiService.ifPresent(service -> requestAttributes.put("zappiService", service));
+        zappiService.ifPresent(service -> {
+            requestAttributes.put("zappiService", service);
+            requestAttributes.put("zappiStatusSummary", executorService.submit(() ->  service.getStatusSummary()));
+        });
     }
 }

--- a/myzappi-alexa-lambda/src/test/java/com/amcglynn/myzappi/TestData.java
+++ b/myzappi-alexa-lambda/src/test/java/com/amcglynn/myzappi/TestData.java
@@ -63,6 +63,14 @@ public class TestData {
     }
 
     public HandlerInput handlerInput(ServiceClientFactory serviceClientFactory) {
+        var requestAttributes = new HashMap<String, Object>();
+        requestAttributes.put("zoneId", ZoneId.of("Europe/Dublin"));
+        requestAttributes.put("zappiService", mockZappiService);
+        requestAttributes.put("userId", "mockUserId");
+        return handlerInput(requestAttributes, serviceClientFactory);
+    }
+
+    public HandlerInput handlerInput(Map<String, Object> additionalRequestAttributes, ServiceClientFactory serviceClientFactory) {
         var handlerInput = HandlerInput.builder()
                 .withServiceClientFactory(serviceClientFactory)
                 .withContext(Context.builder()
@@ -74,7 +82,7 @@ public class TestData {
                                 .build())
                         .build())
                 .withRequestEnvelope(requestEnvelopeBuilder().build()).build();
-        var requestAttributes = new HashMap<String, Object>();
+        var requestAttributes = new HashMap<>(additionalRequestAttributes);
         requestAttributes.put("zoneId", ZoneId.of("Europe/Dublin"));
         requestAttributes.put("zappiService", mockZappiService);
         requestAttributes.put("userId", "mockUserId");

--- a/myzappi-alexa-lambda/src/test/java/com/amcglynn/myzappi/handlers/SetChargeModeHandlerTest.java
+++ b/myzappi-alexa-lambda/src/test/java/com/amcglynn/myzappi/handlers/SetChargeModeHandlerTest.java
@@ -1,12 +1,5 @@
 package com.amcglynn.myzappi.handlers;
 
-import com.amazon.ask.dispatcher.request.handler.HandlerInput;
-import com.amazon.ask.model.Intent;
-import com.amazon.ask.model.IntentRequest;
-import com.amazon.ask.model.RequestEnvelope;
-import com.amazon.ask.model.Session;
-import com.amazon.ask.model.Slot;
-import com.amazon.ask.model.User;
 import com.amcglynn.myenergi.ChargeStatus;
 import com.amcglynn.myenergi.EvConnectionStatus;
 import com.amcglynn.myenergi.ZappiChargeMode;
@@ -14,8 +7,6 @@ import com.amcglynn.myenergi.ZappiStatusSummary;
 import com.amcglynn.myenergi.apiresponse.ZappiStatus;
 import com.amcglynn.myenergi.exception.InvalidResponseFormatException;
 import com.amcglynn.myzappi.TestData;
-import com.amcglynn.myzappi.UserIdResolverFactory;
-import com.amcglynn.myzappi.core.service.MyEnergiService;
 import com.amcglynn.myzappi.core.service.ZappiService;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,7 +22,7 @@ import org.mockito.quality.Strictness;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
 import static com.amcglynn.myzappi.handlers.ResponseVerifier.verifySimpleCardInResponse;
@@ -52,15 +43,18 @@ class SetChargeModeHandlerTest {
 
     private SetChargeModeHandler handler;
     private TestData testData;
+    private Future<List<ZappiStatusSummary>> statusSummaryFuture;
 
     @BeforeEach
     void setUp() {
         testData = new TestData("SetChargeMode", mockZappiService);
+        var executorService = MoreExecutors.newDirectExecutorService();
         when(mockZappiService.getStatusSummary()).thenReturn(List.of(new ZappiStatusSummary(
                 new ZappiStatus("12345678", 0L, 0L,
                         0.0, 0L, ZappiChargeMode.ECO_PLUS.getApiValue(),
-                        ChargeStatus.DIVERTING.ordinal(), EvConnectionStatus.EV_CONNECTED.getCode()))));
-        handler = new SetChargeModeHandler(MoreExecutors.newDirectExecutorService());
+                        ChargeStatus.DIVERTING.ordinal(), EvConnectionStatus.EV_DISCONNECTED.getCode()))));
+        statusSummaryFuture = executorService.submit(() -> mockZappiService.getStatusSummary());
+        handler = new SetChargeModeHandler();
     }
 
     @Test
@@ -78,7 +72,7 @@ class SetChargeModeHandlerTest {
     void testHandle(ZappiChargeMode zappiChargeMode) {
         testData = new TestData("SetChargeMode", mockZappiService, Map.of("ChargeMode", zappiChargeMode.getDisplayName()));
 
-        var result = handler.handle(testData.handlerInput());
+        var result = handler.handle(testData.handlerInput(Map.of("zappiStatusSummary", statusSummaryFuture), null));
         assertThat(result).isPresent();
 
         verifySpeechInResponse(result.get(), "<speak>Changing charge mode to "
@@ -89,11 +83,27 @@ class SetChargeModeHandlerTest {
         verify(mockZappiService).setChargeMode(zappiChargeMode);
     }
 
+    @ParameterizedTest
+    @MethodSource("escalatedZappiChargeMode")
+    void testHandleInformsTheUserThatTheirEvIsntConnectedWhenChargeModeIsEscalated(ZappiChargeMode zappiChargeMode) {
+        testData = new TestData("SetChargeMode", mockZappiService, Map.of("ChargeMode", zappiChargeMode.getDisplayName()));
+
+        var result = handler.handle(testData.handlerInput(Map.of("zappiStatusSummary", statusSummaryFuture), null));
+        assertThat(result).isPresent();
+
+        verifySpeechInResponse(result.get(), "<speak>Changing charge mode to "
+                + zappiChargeMode.getDisplayName() + ". This may take a few minutes. By the way, your E.V. is not connected.</speak>");
+        verifySimpleCardInResponse(result.get(), "My Zappi", "Changing charge mode to " +
+                zappiChargeMode.getDisplayName() + ". This may take a few minutes.\nBy the way, your E.V. is not connected.");
+
+        verify(mockZappiService).setChargeMode(zappiChargeMode);
+    }
+
     @Test
     void testGetStatusFailsInSeparateThreadExpectTheChargeModeToStillBeSet() {
         doThrow(new InvalidResponseFormatException()).when(mockZappiService).getStatusSummary();
         testData = new TestData("SetChargeMode", mockZappiService, Map.of("ChargeMode", ZappiChargeMode.ECO_PLUS.getDisplayName()));
-        var result = handler.handle(testData.handlerInput());
+        var result = handler.handle(testData.handlerInput(Map.of("zappiStatusSummary", statusSummaryFuture), null));
         assertThat(result).isPresent();
 
         verifySpeechInResponse(result.get(), "<speak>Changing charge mode to "
@@ -120,7 +130,11 @@ class SetChargeModeHandlerTest {
     private static Stream<Arguments> zappiChargeMode() {
         return Stream.of(
                 Arguments.of(ZappiChargeMode.STOP),
-                Arguments.of(ZappiChargeMode.ECO_PLUS),
+                Arguments.of(ZappiChargeMode.ECO_PLUS));
+    }
+
+    private static Stream<Arguments> escalatedZappiChargeMode() {
+        return Stream.of(
                 Arguments.of(ZappiChargeMode.ECO),
                 Arguments.of(ZappiChargeMode.FAST));
     }


### PR DESCRIPTION
Added retrieving the zappi status to all commands so that more detailed information can be given in intent responses. This is spawned off on it's own thread and can be joined with the current thread by joining the future