### PR TITLE
Added APL to launch screen on Echo Show devices

### DIFF
--- a/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/MyZappiSkillStreamHandler.java
+++ b/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/MyZappiSkillStreamHandler.java
@@ -9,6 +9,7 @@ import com.amcglynn.myzappi.core.dal.AlexaToLwaLookUpRepository;
 import com.amcglynn.myzappi.core.service.Clock;
 import com.amcglynn.myzappi.handlers.BoostEddiHandler;
 import com.amcglynn.myzappi.handlers.ChargeMyCarHandler;
+import com.amcglynn.myzappi.handlers.EventBrokerHandler;
 import com.amcglynn.myzappi.handlers.FallbackHandler;
 import com.amcglynn.myzappi.handlers.GetChargeModeHandler;
 import com.amcglynn.myzappi.handlers.GetChargeRateHandler;
@@ -110,6 +111,7 @@ public class MyZappiSkillStreamHandler extends SkillStreamHandler {
                         userIdResolverFactory))
                 .addRequestHandler(new SetLibbiDisabledHandler(serviceManager.getMyEnergiServiceBuilder(),
                         userIdResolverFactory))
+                .addRequestHandler(new EventBrokerHandler())
                 .addExceptionHandler(new MyZappiExceptionHandler())
                 .build());
     }

--- a/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/EventBrokerHandler.java
+++ b/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/EventBrokerHandler.java
@@ -1,0 +1,63 @@
+package com.amcglynn.myzappi.handlers;
+
+import com.amazon.ask.dispatcher.request.handler.HandlerInput;
+import com.amazon.ask.dispatcher.request.handler.RequestHandler;
+import com.amazon.ask.model.Response;
+import com.amazon.ask.model.interfaces.alexa.presentation.apl.UserEvent;
+import com.amcglynn.myenergi.ZappiChargeMode;
+import com.amcglynn.myzappi.core.Brand;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.amazon.ask.request.Predicates.requestType;
+import static com.amcglynn.myzappi.LocalisedResponse.cardResponse;
+import static com.amcglynn.myzappi.LocalisedResponse.voiceResponse;
+import static com.amcglynn.myzappi.RequestAttributes.getZappiServiceOrThrow;
+
+public class EventBrokerHandler implements RequestHandler {
+
+    @Override
+    public boolean canHandle(HandlerInput input) {
+        // Check if the request is an APL UserEvent request
+        return input.matches(requestType(UserEvent.class));
+    }
+
+    @Override
+    public Optional<Response> handle(HandlerInput handlerInput) {
+        var userEvent = (UserEvent) handlerInput.getRequestEnvelope().getRequest();
+
+        // Extract arguments from the UserEvent request
+        if (userEvent.getArguments() != null && !userEvent.getArguments().isEmpty()) {
+            var command = userEvent.getArguments().get(0).toString();
+
+            if (command.equals("setChargeMode")) {
+                return handleSetChargeMode(handlerInput, userEvent);
+            }
+            // Perform actions based on event argument
+            System.out.println("Received APL UserEvent with argument: " + command);
+
+            // Add any logic based on the user event, such as handling button clicks or other interactions
+        }
+
+        // Send a response if needed (can be empty or confirm interaction)
+        return handlerInput.getResponseBuilder()
+                .withSpeech("Received your selection!")
+                .withShouldEndSession(false)
+                .build();
+    }
+
+    private Optional<Response> handleSetChargeMode(HandlerInput handlerInput, UserEvent userEvent) {
+        var chargeMode = userEvent.getArguments().get(1).toString();
+
+        var newChargeMode = ZappiChargeMode.valueOf(chargeMode);
+        getZappiServiceOrThrow(handlerInput).setChargeMode(newChargeMode);
+        var voiceResponse = voiceResponse(handlerInput, "change-charge-mode", Map.of("zappiChargeMode", newChargeMode.getDisplayName()));
+        var cardResponse = cardResponse(handlerInput, "change-charge-mode", Map.of("zappiChargeMode", newChargeMode.getDisplayName()));
+        return handlerInput.getResponseBuilder()
+                .withSpeech(voiceResponse)
+                .withSimpleCard(Brand.NAME, cardResponse)
+                .withShouldEndSession(false)
+                .build();
+    }
+}

--- a/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/LaunchHandler.java
+++ b/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/LaunchHandler.java
@@ -4,15 +4,29 @@ import com.amazon.ask.dispatcher.request.handler.HandlerInput;
 import com.amazon.ask.dispatcher.request.handler.impl.LaunchRequestHandler;
 import com.amazon.ask.model.LaunchRequest;
 import com.amazon.ask.model.Response;
+import com.amazon.ask.model.interfaces.alexa.presentation.apl.RenderDocumentDirective;
+import com.amazon.ask.request.RequestHelper;
+import com.amazon.ask.response.ResponseBuilder;
 import com.amcglynn.myzappi.core.Brand;
 import com.amcglynn.myzappi.core.config.Properties;
+import com.amcglynn.myzappi.core.exception.MissingDeviceException;
+import com.amcglynn.myzappi.handlers.responses.ZappiStatusSummaryCardResponse;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.amazon.ask.request.Predicates.requestType;
 import static com.amcglynn.myzappi.LocalisedResponse.cardResponse;
 import static com.amcglynn.myzappi.LocalisedResponse.voiceResponse;
+import static com.amcglynn.myzappi.RequestAttributes.getZappiServiceOrThrow;
 
 @Slf4j
 public class LaunchHandler implements LaunchRequestHandler {
@@ -34,9 +48,10 @@ public class LaunchHandler implements LaunchRequestHandler {
 
     @Override
     public Optional<Response> handle(HandlerInput handlerInput, LaunchRequest launchRequest) {
+        var responseBuilder = handlerInput.getResponseBuilder();
         if (handlerInput.getRequestEnvelope().getSession()
                 .getApplication().getApplicationId().equals(properties.getEddiSkillId())) {
-            return handlerInput.getResponseBuilder()
+            return responseBuilder
                     .withSpeech(voiceResponse(handlerInput, "eddi-help"))
                     .withSimpleCard(Brand.NAME, cardResponse(handlerInput, "eddi-help"))
                     .withShouldEndSession(false)
@@ -45,17 +60,60 @@ public class LaunchHandler implements LaunchRequestHandler {
 
         if (handlerInput.getRequestEnvelope().getSession()
                 .getApplication().getApplicationId().equals(properties.getLibbiSkillId())) {
-            return handlerInput.getResponseBuilder()
+            return responseBuilder
                     .withSpeech(voiceResponse(handlerInput, "libbi-help"))
                     .withSimpleCard(Brand.NAME, cardResponse(handlerInput, "libbi-help"))
                     .withShouldEndSession(false)
                     .build();
         }
 
-        return handlerInput.getResponseBuilder()
+        if (hasDisplayInterface(handlerInput)) {
+            try {
+                return responseBuilder
+                        .withSpeech("OK")
+                        .withSimpleCard(Brand.NAME, cardResponse(handlerInput, "help"))
+                        .addDirective(buildControlPanel(handlerInput))
+                        .withShouldEndSession(false)
+                        .build();
+            } catch (MissingDeviceException e) {
+                // not going to do anything if there is no zappi configured
+            }
+        }
+        return responseBuilder
                 .withSpeech(voiceResponse(handlerInput, "help"))
                 .withSimpleCard(Brand.NAME, cardResponse(handlerInput, "help"))
                 .withShouldEndSession(false)
                 .build();
+    }
+
+    private RenderDocumentDirective buildControlPanel(HandlerInput handlerInput) {
+        var locale = Locale.forLanguageTag(handlerInput.getRequestEnvelope().getRequest().getLocale());
+        var summary = getZappiServiceOrThrow(handlerInput).getStatusSummary();
+        var content = new ZappiStatusSummaryCardResponse(locale, summary.get(0)).toString().replace("\n", "<br>");
+
+        return RenderDocumentDirective.builder()
+                .withToken("zappidaysummaryToken")
+                .withDocument(buildDocument(content))
+                .build();
+    }
+
+    @SneakyThrows
+    private Map<String, Object> buildDocument(String summaryContent) {
+        ObjectMapper mapper = new ObjectMapper();
+        TypeReference<HashMap<String, Object>> documentMapType = new TypeReference<>() {
+        };
+
+        InputStream inputStream = getClass().getClassLoader().getResourceAsStream("apl/zappi-control-panel.json");
+
+        var contents = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        contents = contents.replace("${payload.energySummary}", summaryContent);
+
+        return mapper.readValue(contents, documentMapType);
+    }
+
+    private boolean hasDisplayInterface(HandlerInput handlerInput) {
+        return RequestHelper.forHandlerInput(handlerInput)
+                .getSupportedInterfaces()
+                .getAlexaPresentationAPL() != null;
     }
 }

--- a/myzappi-alexa-lambda/src/main/resources/apl/zappi-control-panel.json
+++ b/myzappi-alexa-lambda/src/main/resources/apl/zappi-control-panel.json
@@ -1,0 +1,86 @@
+{
+  "type": "APL",
+  "version": "1.8",
+  "import": [
+    {
+      "name": "alexa-layouts",
+      "version": "1.7.0"
+    }
+  ],
+  "mainTemplate": {
+    "items": [
+      {
+        "type": "Container",
+        "direction": "column",
+        "alignItems": "center",
+        "justifyContent": "center",
+        "width": "100vw",
+        "height": "100vh",
+        "items": [
+          {
+            "type": "Text",
+            "text": "${payload.energySummary}",
+            "fontSize": "24dp",
+            "color": "white",
+            "textAlign": "left",
+            "paddingBottom": "20dp"
+          },
+          {
+            "type": "Container",
+            "direction": "row",
+            "spacing": "20dp",
+            "alignItems": "center",
+            "justifyContent": "center",
+            "width": "100vw",
+            "items": [
+              {
+                "type": "AlexaButton",
+                "buttonText": "Eco",
+                "primaryAction": {
+                  "type": "SendEvent",
+                  "arguments": [
+                    "setChargeMode",
+                    "ECO"
+                  ]
+                }
+              },
+              {
+                "type": "AlexaButton",
+                "buttonText": "Eco+",
+                "primaryAction": {
+                  "type": "SendEvent",
+                  "arguments": [
+                    "setChargeMode",
+                    "ECO_PLUS"
+                  ]
+                }
+              },
+              {
+                "type": "AlexaButton",
+                "buttonText": "Fast",
+                "primaryAction": {
+                  "type": "SendEvent",
+                  "arguments": [
+                    "setChargeMode",
+                    "FAST"
+                  ]
+                }
+              },
+              {
+                "type": "AlexaButton",
+                "buttonText": "Stop",
+                "primaryAction": {
+                  "type": "SendEvent",
+                  "arguments": [
+                    "setChargeMode",
+                    "STOP"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/myzappi-alexa-lambda/src/test/java/com/amcglynn/myzappi/MyZappiSkillStreamHandlerTest.java
+++ b/myzappi-alexa-lambda/src/test/java/com/amcglynn/myzappi/MyZappiSkillStreamHandlerTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
  */
 class MyZappiSkillStreamHandlerTest {
 
-    private static final int EXPECTED_NUMBER_OF_INTENT_HANDLERS = 38;
+    private static final int EXPECTED_NUMBER_OF_INTENT_HANDLERS = 40;
 
     @Test
     void testConstructorDoesNotThrowAnException() {

--- a/myzappi-alexa-lambda/src/test/java/com/amcglynn/myzappi/TestData.java
+++ b/myzappi-alexa-lambda/src/test/java/com/amcglynn/myzappi/TestData.java
@@ -1,6 +1,7 @@
 package com.amcglynn.myzappi;
 
 import com.amazon.ask.dispatcher.request.handler.HandlerInput;
+import com.amazon.ask.model.Application;
 import com.amazon.ask.model.Context;
 import com.amazon.ask.model.Device;
 import com.amazon.ask.model.Intent;
@@ -10,6 +11,7 @@ import com.amazon.ask.model.Session;
 import com.amazon.ask.model.Slot;
 import com.amazon.ask.model.SupportedInterfaces;
 import com.amazon.ask.model.User;
+import com.amazon.ask.model.interfaces.alexa.presentation.apl.AlexaPresentationAplInterface;
 import com.amazon.ask.model.interfaces.system.SystemState;
 import com.amazon.ask.model.services.ServiceClientFactory;
 import com.amcglynn.myzappi.core.service.ZappiService;
@@ -50,12 +52,11 @@ public class TestData {
     private RequestEnvelope.Builder requestEnvelopeBuilder() {
         return RequestEnvelope.builder()
                 .withRequest(intentRequest)
-                .withContext(Context.builder()
-                        .withSystem(SystemState.builder().withDevice(Device.builder().withDeviceId("myDeviceId")
-                                        .build())
-                                .build())
-                        .build())
-                .withSession(Session.builder().withUser(User.builder().withUserId("userId").build()).build());
+                .withContext(getContext())
+                .withSession(Session.builder()
+                        .withUser(User.builder().withUserId("userId").build())
+                        .withApplication(Application.builder().withApplicationId("eddiSkill").build())
+                        .build());
     }
 
     public HandlerInput handlerInput() {
@@ -73,14 +74,7 @@ public class TestData {
     public HandlerInput handlerInput(Map<String, Object> additionalRequestAttributes, ServiceClientFactory serviceClientFactory) {
         var handlerInput = HandlerInput.builder()
                 .withServiceClientFactory(serviceClientFactory)
-                .withContext(Context.builder()
-                        .withSystem(SystemState.builder()
-                                .withDevice(Device.builder()
-                                        .withDeviceId("myDeviceId")
-                                        .withSupportedInterfaces(SupportedInterfaces.builder().build())
-                                        .build())
-                                .build())
-                        .build())
+                .withContext(getContext())
                 .withRequestEnvelope(requestEnvelopeBuilder().build()).build();
         var requestAttributes = new HashMap<>(additionalRequestAttributes);
         requestAttributes.put("zoneId", ZoneId.of("Europe/Dublin"));
@@ -89,4 +83,19 @@ public class TestData {
         handlerInput.getAttributesManager().setRequestAttributes(requestAttributes);
         return handlerInput;
     }
+
+    private static Context getContext() {
+        return Context.builder()
+                .withSystem(SystemState.builder()
+                        .withDevice(Device.builder()
+                                .withDeviceId("myDeviceId")
+                                .withSupportedInterfaces(SupportedInterfaces.builder()
+                                        .withAlexaPresentationAPL(AlexaPresentationAplInterface.builder().build())
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+    }
+
+
 }

--- a/myzappi-alexa-lambda/src/test/java/com/amcglynn/myzappi/handlers/LaunchIntentHandlerTest.java
+++ b/myzappi-alexa-lambda/src/test/java/com/amcglynn/myzappi/handlers/LaunchIntentHandlerTest.java
@@ -2,34 +2,57 @@ package com.amcglynn.myzappi.handlers;
 
 import com.amazon.ask.dispatcher.request.handler.HandlerInput;
 import com.amazon.ask.model.Application;
+import com.amazon.ask.model.Context;
+import com.amazon.ask.model.Device;
 import com.amazon.ask.model.Intent;
 import com.amazon.ask.model.IntentRequest;
 import com.amazon.ask.model.LaunchRequest;
 import com.amazon.ask.model.RequestEnvelope;
 import com.amazon.ask.model.Session;
+import com.amazon.ask.model.SupportedInterfaces;
 import com.amazon.ask.model.User;
+import com.amazon.ask.model.interfaces.alexa.presentation.apl.AlexaPresentationAplInterface;
+import com.amazon.ask.model.interfaces.alexa.presentation.html.AlexaPresentationHtmlInterface;
+import com.amazon.ask.model.interfaces.system.SystemState;
 import com.amazon.ask.model.ui.SimpleCard;
 import com.amazon.ask.model.ui.SsmlOutputSpeech;
+import com.amcglynn.myenergi.ChargeStatus;
+import com.amcglynn.myenergi.EvConnectionStatus;
+import com.amcglynn.myenergi.ZappiChargeMode;
+import com.amcglynn.myenergi.ZappiStatusSummary;
+import com.amcglynn.myenergi.apiresponse.ZappiStatus;
+import com.amcglynn.myzappi.TestData;
 import com.amcglynn.myzappi.core.Brand;
 import com.amcglynn.myzappi.core.config.Properties;
+import com.amcglynn.myzappi.core.service.ZappiService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+@MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
 @ExtendWith(MockitoExtension.class)
 class LaunchIntentHandlerTest {
 
     private LaunchHandler handler;
     @Mock
     private Properties mockProperties;
+    @Mock
+    private ZappiService mockZappiService;
 
     @BeforeEach
     void setUp() {
+        when(mockZappiService.getStatusSummary()).thenReturn(List.of(new ZappiStatusSummary(
+                new ZappiStatus("12345678", 1500L, 1400L,
+                        24.3, 1000L, ZappiChargeMode.ECO_PLUS.getApiValue(),
+                        ChargeStatus.BOOSTING.ordinal(), EvConnectionStatus.CHARGING.getCode()))));
         handler = new LaunchHandler(mockProperties);
     }
 
@@ -49,7 +72,7 @@ class LaunchIntentHandlerTest {
 
     @Test
     void testHandleSpeechResponse() {
-        var response = handler.handle(HandlerInput.builder().withRequestEnvelope(requestEnvelopeBuilder().build()).build());
+        var response = handler.handle(handlerInputBuilder().build());
         assertThat(response).isPresent();
         assertThat(response.get().getOutputSpeech()).isInstanceOf(SsmlOutputSpeech.class);
 
@@ -78,6 +101,7 @@ class LaunchIntentHandlerTest {
     void testHandleSpeechResponseItalian() {
         var response = handler.handle(HandlerInput.builder().withRequestEnvelope(RequestEnvelope.builder()
                 .withRequest(LaunchRequest.builder().withLocale("it-IT").build())
+                        .withContext(buildContext())
                 .withSession(Session.builder()
                         .withApplication(Application.builder().withApplicationId("appId").build()).build())
                 .build()).build());
@@ -102,11 +126,33 @@ class LaunchIntentHandlerTest {
                 "Ask me to start charging or to switch to solar. You can also ask me for an energy summary.");
     }
 
+    @Test
+    void testReturnAplControlPanelWhenAplDeviceIsSupportedAndDeviceIsRegistered() {
+        var response = handler.handle(new TestData("LaunchRequest", mockZappiService).handlerInput(), LaunchRequest.builder().build());
+        assertThat(response).isPresent();
+        assertThat(response.get().getOutputSpeech()).isInstanceOf(SsmlOutputSpeech.class);
+
+        var outputSpeech = (SsmlOutputSpeech) response.get().getOutputSpeech();
+        assertThat(outputSpeech.getSsml()).isEqualTo("<speak>OK</speak>");
+    }
+
     private RequestEnvelope.Builder requestEnvelopeBuilder() {
         return RequestEnvelope.builder()
                 .withRequest(initIntentRequest())
+                .withContext(buildContext())
                 .withSession(Session.builder().withUser(User.builder().withUserId("test").build())
                         .withApplication(Application.builder().withApplicationId("appId").build()).build());
+    }
+
+    private Context buildContext() {
+        return Context.builder()
+                .withSystem(SystemState.builder().withDevice(Device.builder().withDeviceId("myDeviceId")
+                                .withSupportedInterfaces(SupportedInterfaces.builder()
+                                        .withAlexaPresentationAPL(AlexaPresentationAplInterface.builder().build())
+                                        .build())
+                                .build())
+                        .build())
+                .build();
     }
 
     private LaunchRequest initIntentRequest() {


### PR DESCRIPTION
Added UI responses to devices that support APL, like Echo Show. 
The user can view the Zappi summary from the screen and can also change the charge mode via the screen, without the need for voice commands.
<img width="1197" alt="Screenshot 2024-10-30 at 08 28 23" src="https://github.com/user-attachments/assets/ab87b0a6-c3af-4416-b759-60d55c610f45">
