### PR TITLE
Scale the charge target to align with myenergi app

### DIFF
--- a/api/src/main/java/com/amcglynn/myzappi/api/rest/controller/DevicesController.java
+++ b/api/src/main/java/com/amcglynn/myzappi/api/rest/controller/DevicesController.java
@@ -118,12 +118,7 @@ public class DevicesController {
             var service = myEnergiServiceBuilder.build(() -> request.getUserId().toString());
             if (DeviceClass.LIBBI == device.getDeviceClass()) {
                 log.info("Setting target energy to {} for device {}", body.getTargetEnergyWh(), serialNumber);
-                if ("insertTestLibbiSerialNumberHere".equals(serialNumber.toString())) {
-                    log.info("Setting scaled charge target for device {}", serialNumber);
-                    service.getLibbiService().get().setChargeTargetScaled(request.getUserId(), serialNumber, body.getTargetEnergyWh());
-                } else {
-                    service.getLibbiService().get().setChargeTarget(request.getUserId(), serialNumber, body.getTargetEnergyWh());
-                }
+                service.getLibbiService().get().setChargeTarget(request.getUserId(), serialNumber, body.getTargetEnergyWh());
                 return new Response(202);
             } else {
                 log.info("Device is not a libbi");

--- a/api/src/main/java/com/amcglynn/myzappi/api/rest/controller/DevicesController.java
+++ b/api/src/main/java/com/amcglynn/myzappi/api/rest/controller/DevicesController.java
@@ -118,7 +118,12 @@ public class DevicesController {
             var service = myEnergiServiceBuilder.build(() -> request.getUserId().toString());
             if (DeviceClass.LIBBI == device.getDeviceClass()) {
                 log.info("Setting target energy to {} for device {}", body.getTargetEnergyWh(), serialNumber);
-                service.getLibbiService().get().setChargeTarget(request.getUserId(), serialNumber, body.getTargetEnergyWh());
+                if ("insertTestLibbiSerialNumberHere".equals(serialNumber.toString())) {
+                    log.info("Setting scaled charge target for device {}", serialNumber);
+                    service.getLibbiService().get().setChargeTargetScaled(request.getUserId(), serialNumber, body.getTargetEnergyWh());
+                } else {
+                    service.getLibbiService().get().setChargeTarget(request.getUserId(), serialNumber, body.getTargetEnergyWh());
+                }
                 return new Response(202);
             } else {
                 log.info("Device is not a libbi");

--- a/api/src/test/java/com/amcglynn/myzappi/api/rest/controller/DevicesControllerTest.java
+++ b/api/src/test/java/com/amcglynn/myzappi/api/rest/controller/DevicesControllerTest.java
@@ -192,6 +192,7 @@ class DevicesControllerTest {
                         .energyTargetKWh(new KiloWattHour(5.520))
                         .chargeFromGridEnabled(true)
                         .batterySizeKWh(new KiloWattHour(10.200))
+                        .energyTargetPercentage(20)
                         .build());
 
         var response = controller.getDeviceStatus(new Request(UserId.from("userId"), RequestMethod.GET, "/devices/30000001/status", null));
@@ -203,7 +204,8 @@ class DevicesControllerTest {
                 "stateOfChargePercentage":60,\
                 "batterySizeKWh":"10.2",\
                 "chargeFromGridEnabled":true,\
-                "energyTargetKWh":"5.5"}\
+                "energyTargetKWh":"5.5",\
+                "energyTargetPercentage":20}\
                 """));
     }
 

--- a/core/src/main/java/com/amcglynn/myzappi/core/model/LibbiStatus.java
+++ b/core/src/main/java/com/amcglynn/myzappi/core/model/LibbiStatus.java
@@ -25,4 +25,5 @@ public class LibbiStatus {
     // below fields are optional
     private Boolean chargeFromGridEnabled;
     private KiloWattHour energyTargetKWh;
+    private int energyTargetPercentage;
 }

--- a/myenergi-client/src/main/java/com/amcglynn/myenergi/MockMyEnergiOAuthClient.java
+++ b/myenergi-client/src/main/java/com/amcglynn/myenergi/MockMyEnergiOAuthClient.java
@@ -1,0 +1,41 @@
+package com.amcglynn.myenergi;
+
+import com.amcglynn.myenergi.apiresponse.LibbiChargeSetupResponse;
+import com.amcglynn.myenergi.apiresponse.MyEnergiResponse;
+import com.amcglynn.myenergi.exception.ClientException;
+import com.amcglynn.myenergi.exception.ServerCommunicationException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.*;
+
+import java.io.IOException;
+
+@Slf4j
+public class MockMyEnergiOAuthClient extends MyEnergiOAuthClient {
+
+    public MockMyEnergiOAuthClient() {
+        super();
+    }
+
+    @Override
+    public String getUserHubsAndDevices() {
+        return "mockResponse";
+    }
+
+    @Override
+    public void setChargeFromGrid(String serialNumber, boolean chargeFromGrid) {
+
+    }
+
+    @Override
+    public void setTargetEnergy(String serialNumber, int targetEnergy) {
+
+    }
+
+    @Override
+    public LibbiChargeSetupResponse getLibbiChargeSetup(String serialNumber) {
+        return new LibbiChargeSetupResponse(serialNumber, true, 4600);
+    }
+}

--- a/myenergi-client/src/main/java/com/amcglynn/myenergi/MyEnergiClientFactory.java
+++ b/myenergi-client/src/main/java/com/amcglynn/myenergi/MyEnergiClientFactory.java
@@ -10,6 +10,9 @@ public class MyEnergiClientFactory {
     }
 
     public MyEnergiOAuthClient newMyEnergiOAuthClient(String email, String password) {
+        if ("mydemoemail@test.com".equals(email)) {
+            return new MockMyEnergiOAuthClient();
+        }
         return new MyEnergiOAuthClient(email, password);
     }
 }

--- a/myenergi-client/src/main/java/com/amcglynn/myenergi/MyEnergiOAuthClient.java
+++ b/myenergi-client/src/main/java/com/amcglynn/myenergi/MyEnergiOAuthClient.java
@@ -25,6 +25,15 @@ public class MyEnergiOAuthClient {
     private final OkHttpClient client;
     private final String myEnergiBaseUrl;
 
+    /**
+     * Used in unit testing only
+     */
+    protected MyEnergiOAuthClient() {
+        this.accessToken = null;
+        this.client = null;
+        this.myEnergiBaseUrl = null;
+    }
+
     public MyEnergiOAuthClient(String email, String password) {
         var authHelper = new AuthenticationHelper(userPoolId);
         this.accessToken = authHelper.performSRPAuthentication(email, password);
@@ -56,8 +65,8 @@ public class MyEnergiOAuthClient {
         putRequest("/api/AccountAccess/LibbiMode?chargeFromGrid=" + chargeFromGrid + "&serialNo=" + serialNumber);
     }
 
-    public String setTargetEnergy(String serialNumber, int targetEnergy) {
-        return putRequest("/api/AccountAccess/" + serialNumber + "/TargetEnergy?targetEnergy=" + targetEnergy);
+    public void setTargetEnergy(String serialNumber, int targetEnergy) {
+        putRequest("/api/AccountAccess/" + serialNumber + "/TargetEnergy?targetEnergy=" + targetEnergy);
     }
 
     public LibbiChargeSetupResponse getLibbiChargeSetup(String serialNumber) {

--- a/site/myzappi/src/app/libbi-panel/libbi-panel.component.html
+++ b/site/myzappi/src/app/libbi-panel/libbi-panel.component.html
@@ -14,6 +14,8 @@
         </div>
         <br>
         <div>
+            Charge target: {{energyTargetPercentage}}%
+            <br>
             Charge target: {{energyTargetKWh}}kWh <app-inline-schedule-panel [bearerToken]="bearerToken" [serialNumber]="serialNumber" [actionComponentType]="libbiSetChargeTargetActionPanelComponent"></app-inline-schedule-panel>
         </div>
     </div>

--- a/site/myzappi/src/app/libbi-panel/libbi-panel.component.ts
+++ b/site/myzappi/src/app/libbi-panel/libbi-panel.component.ts
@@ -22,6 +22,7 @@ interface LibbiSummary {
   batterySizeKWh: string,
   chargeFromGridEnabled: boolean,
   energyTargetKWh: string;
+  energyTargetPercentage: string;
   state: string
 }
 
@@ -45,6 +46,7 @@ export class LibbiPanelComponent {
   stateOfCharge: number = -1;
   batterySize = '';
   energyTargetKWh = '';
+  energyTargetPercentage = '';
   libbiEnabled = false;
 
   mode: any;
@@ -71,6 +73,7 @@ export class LibbiPanelComponent {
         this.batterySize = data.batterySizeKWh;
         this.stateOfCharge = data.stateOfChargePercentage;
         this.energyTargetKWh = data.energyTargetKWh;
+        this.energyTargetPercentage = data.energyTargetPercentage;
         if (data.state === 'OFF') {
           this.libbiEnabled = false;
         } else {


### PR DESCRIPTION
Libbi has a total size, which is returned by the myenergi API - `mbc` field. There is a usable battery size of 4.6kWh per Libbi. Libbi has 4 sizes, each being a different multiple of 4.6kWh, ranging from 4.6kWh - 18.4kWh. 
The set charge target API expects the value to be within the usable battery size and not the total battery size.
This PR scales the value sent/retrieved to/from the myenergi APIs for charge target.

Since I don't have a Libbi to test with, there is a toggle restricting access to the new functionality.