### PR TITLE
Fixed get charge target to scale with the usable battery size

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Task list:
 Launch screen
 Add QR code: https://s3.eu-west-1.amazonaws.com/www.myzappiunofficial.com/assets/images/qrcode.jpg
-
+* Update UI to update libbi charge target in 5% increments
 
 SetChargeMode
 1. Prompt the user to confirm if they want to unlock the charge mode if it is locked

--- a/api/src/main/java/com/amcglynn/myzappi/api/rest/controller/DevicesController.java
+++ b/api/src/main/java/com/amcglynn/myzappi/api/rest/controller/DevicesController.java
@@ -226,6 +226,5 @@ public class DevicesController {
         } else {
             throw new ServerException(404);
         }
-//        return myEnergiServiceBuilder.build().getZappiService()request.getUserId(), SerialNumber.from(deviceId));
     }
 }

--- a/core/src/main/java/com/amcglynn/myzappi/core/service/LibbiService.java
+++ b/core/src/main/java/com/amcglynn/myzappi/core/service/LibbiService.java
@@ -84,24 +84,6 @@ public class LibbiService {
     }
 
     public void setChargeTarget(UserId userId, SerialNumber serialNumber, int targetEnergy) {
-        if ("earlyAccessSerialNumber".equals(serialNumber.toString())) {
-            setChargeTargetScaled(userId, serialNumber, targetEnergy);
-            return;
-        }
-        var creds = loginService.readMyEnergiAccountCredentials(userId);
-
-        creds.ifPresent(cred -> {
-            var libbiStatus = client.getLibbiStatus(serialNumber.toString()).getLibbi().get(0);
-            var batterySize = libbiStatus.getBatterySizeWh();
-            var targetEnergyWh = batterySize * targetEnergy / 100;
-
-            log.info("Setting target energy for serial number {} to {}% {}/{}", serialNumber, targetEnergy, targetEnergyWh, batterySize);
-            clientFactory.newMyEnergiOAuthClient(cred.getEmailAddress(), cred.getPassword())
-                            .setTargetEnergy(serialNumber.toString(), targetEnergyWh);
-            });
-    }
-
-    public void setChargeTargetScaled(UserId userId, SerialNumber serialNumber, int targetEnergy) {
         var creds = loginService.readMyEnergiAccountCredentials(userId);
         log.info("Setting scaled charge target for device {}", serialNumber);
         creds.ifPresent(cred -> {

--- a/core/src/test/java/com/amcglynn/myzappi/core/service/LibbiServiceTest.java
+++ b/core/src/test/java/com/amcglynn/myzappi/core/service/LibbiServiceTest.java
@@ -118,15 +118,15 @@ class LibbiServiceTest {
         when(mockLoginService.readMyEnergiAccountCredentials(userId))
                 .thenReturn(Optional.of(new MyEnergiAccountCredentials(userId.toString(), "user@test.com", "password")));
         service.setChargeTarget(userId, SerialNumber.from("30000001"), 100);
-        verify(mockMyEnergiOAuthClient).setTargetEnergy("30000001", 10200);
+        verify(mockMyEnergiOAuthClient).setTargetEnergy("30000001", 9200);
     }
 
     @MethodSource("chargeTargetPercentForLibbiWith2Batteries")
     @ParameterizedTest
-    void setChargeTargetScaled(int percent, int expectedEnergy) {
+    void setChargeTarget(int percent, int expectedEnergy) {
         when(mockLoginService.readMyEnergiAccountCredentials(userId))
                 .thenReturn(Optional.of(new MyEnergiAccountCredentials(userId.toString(), "user@test.com", "password")));
-        service.setChargeTargetScaled(userId, SerialNumber.from("30000001"), percent);
+        service.setChargeTarget(userId, SerialNumber.from("30000001"), percent);
         verify(mockMyEnergiOAuthClient).setTargetEnergy("30000001", expectedEnergy);
     }
 
@@ -183,7 +183,7 @@ class LibbiServiceTest {
         when(mockLoginService.readMyEnergiAccountCredentials(userId))
                 .thenReturn(Optional.of(new MyEnergiAccountCredentials(userId.toString(), "user@test.com", "password")));
         service.setChargeTarget(userId, SerialNumber.from("30000001"), 50);
-        verify(mockMyEnergiOAuthClient).setTargetEnergy("30000001", 5100);
+        verify(mockMyEnergiOAuthClient).setTargetEnergy("30000001", 4600);
     }
 
     @Test

--- a/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/GetLibbiChargeTargetHandler.java
+++ b/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/GetLibbiChargeTargetHandler.java
@@ -39,16 +39,12 @@ public class GetLibbiChargeTargetHandler implements RequestHandler {
         libbiService.validateMyEnergiAccountIsConfigured(userId);
 
         var status = libbiService.getStatus(userId);
-        var chargeTarget = status.getEnergyTargetKWh();
-        var batterySize = status.getBatterySizeKWh();
-
-        var chargeTargetPercentage = (int) (chargeTarget.getDouble() / batterySize.getDouble() * 100);
 
         return handlerInput.getResponseBuilder()
                 .withSpeech(voiceResponse(handlerInput, "libbi-charge-target-percentage",
-                        Map.of("chargeTargetPercentage", Integer.toString(chargeTargetPercentage))))
+                        Map.of("chargeTargetPercentage", Integer.toString(status.getEnergyTargetPercentage()))))
                 .withSimpleCard(Brand.NAME, cardResponse(handlerInput, "libbi-charge-target-percentage",
-                        Map.of("chargeTargetPercentage", Integer.toString(chargeTargetPercentage))))
+                        Map.of("chargeTargetPercentage", Integer.toString(status.getEnergyTargetPercentage()))))
                 .withShouldEndSession(false)
                 .build();
     }

--- a/myzappi-alexa-lambda/src/test/java/com/amcglynn/myzappi/handlers/GetLibbiChargeTargetHandlerTest.java
+++ b/myzappi-alexa-lambda/src/test/java/com/amcglynn/myzappi/handlers/GetLibbiChargeTargetHandlerTest.java
@@ -76,6 +76,7 @@ class GetLibbiChargeTargetHandlerTest {
                 .state(LibbiState.ON)
                         .batterySizeKWh(new KiloWattHour(10.2))
                         .energyTargetKWh(new KiloWattHour(5.1))
+                        .energyTargetPercentage(50)
                 .build());
         var response = handler.handle(handlerInputBuilder("GetLibbiChargeTarget").build());
         assertThat(response).isPresent();


### PR DESCRIPTION
Bug where Alexa get charge target Libbi command was not updated to use the usable battery. Updated it to reuse the same logic as the website.