### PR TITLE
Provide Libbi state in Website and Alexa

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Task list:
 Launch screen
 Add QR code: https://s3.eu-west-1.amazonaws.com/www.myzappiunofficial.com/assets/images/qrcode.jpg
-* Update UI to update libbi charge target in 5% increments
 
 SetChargeMode
 1. Prompt the user to confirm if they want to unlock the charge mode if it is locked
@@ -14,6 +13,8 @@ Show the energy usage graph as a background image for getting the status. This s
 
 The most popular commands from about 10 months are:
 1. Set charge mode
+-- prompt the user to confirm if they want to unlock the charger if it is locked
+
 2. Go green
 3. Set eddi mode to stopped
 4. Charge my car

--- a/api/src/test/java/com/amcglynn/myzappi/api/rest/controller/DevicesControllerTest.java
+++ b/api/src/test/java/com/amcglynn/myzappi/api/rest/controller/DevicesControllerTest.java
@@ -201,6 +201,7 @@ class DevicesControllerTest {
                 {\
                 "serialNumber":"30000001",\
                 "state":"OFF",\
+                "stateDescription":"Off",\
                 "stateOfChargePercentage":60,\
                 "batterySizeKWh":"10.2",\
                 "chargeFromGridEnabled":true,\

--- a/core/src/main/java/com/amcglynn/myzappi/core/model/LibbiStatus.java
+++ b/core/src/main/java/com/amcglynn/myzappi/core/model/LibbiStatus.java
@@ -20,10 +20,15 @@ public class LibbiStatus {
     @JsonSerialize(using = SerialNumberSerializer.class)
     private SerialNumber serialNumber;
     private LibbiState state;
+    private String stateDescription;
     private int stateOfChargePercentage;
     private KiloWattHour batterySizeKWh;
     // below fields are optional
     private Boolean chargeFromGridEnabled;
     private KiloWattHour energyTargetKWh;
     private int energyTargetPercentage;
+
+    public String getStateDescription() {
+        return state.getDescription();
+    }
 }

--- a/myenergi-client/src/main/java/com/amcglynn/myenergi/LibbiState.java
+++ b/myenergi-client/src/main/java/com/amcglynn/myenergi/LibbiState.java
@@ -1,35 +1,39 @@
 package com.amcglynn.myenergi;
 
+import lombok.Getter;
+
 import java.util.HashMap;
 import java.util.Map;
 
 public enum LibbiState {
     // from https://github.com/CJNE/pymyenergi/pull/16/files
-    OFF(0),
-    ON(1),
-    BATTERY_FULL(2),
-    IDLE(4),
-    CHARGING(5),
-    DISCHARGING(6),
-    DURATION_CHARGING(7),
-    DURATION_DRAIN(8),
-    TARGET_CHARGE(12),
-    BOOSTING(51),
-    BOOSTING2(53),
-    BOOSTING3(55),
-    STOPPED(11),
-    BATTERY_EMPTY(101),
-    FULL(102),
-    FULL2(104),
-    FW_UPGRADE_ARM(151),
-    FW_UPGRADE_DSP(156),
-    BMS_CHARGE_TEMPERATURE_LOW(172),
-    CALIBRATION_CHARGE(234),
-    FW_UPGRADE_DSP2(251),
-    FW_UPGRADE_ARM2(252),
-    UNKNOWN(-1);
+    OFF(0, "Off"),
+    ON(1, "On"),
+    BATTERY_FULL(2, "Full"),
+    IDLE(4, "Idle"),
+    CHARGING(5, "Charging"),
+    DISCHARGING(6, "Discharging"),
+    DURATION_CHARGING(7, "Charging"),
+    DURATION_DRAIN(8, "Discharging"),
+    TARGET_CHARGE(12, "Charging"),
+    BOOSTING(51, "Charging"),
+    BOOSTING2(53, "Charging"),
+    BOOSTING3(55, "Charging"),
+    STOPPED(11, "Stopped"),
+    BATTERY_EMPTY(101, "Empty"),
+    FULL(102, "Full"),
+    FULL2(104, "Full"),
+    FW_UPGRADE_ARM(151, "Upgrading"),
+    FW_UPGRADE_DSP(156, "Upgrading"),
+    BMS_CHARGE_TEMPERATURE_LOW(172, "Stopped"),
+    CALIBRATION_CHARGE(234, "Calibrating"),
+    FW_UPGRADE_DSP2(251, "Upgrading"),
+    FW_UPGRADE_ARM2(252, "Upgrading"),
+    UNKNOWN(-1, "Unknown");
 
     private final int state;
+    @Getter
+    private final String description;
 
     private static final Map<Integer, LibbiState> CODES = new HashMap<>();
 
@@ -39,12 +43,9 @@ public enum LibbiState {
         }
     }
 
-    public int getStateValue() {
-        return this.state;
-    }
-
-    LibbiState(int state) {
+    LibbiState(int state, String description) {
         this.state = state;
+        this.description = description;
     }
 
     public static LibbiState from(int i) {

--- a/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/GetLibbiEnabledHandler.java
+++ b/myzappi-alexa-lambda/src/main/java/com/amcglynn/myzappi/handlers/GetLibbiEnabledHandler.java
@@ -3,7 +3,6 @@ package com.amcglynn.myzappi.handlers;
 import com.amazon.ask.dispatcher.request.handler.HandlerInput;
 import com.amazon.ask.dispatcher.request.handler.RequestHandler;
 import com.amazon.ask.model.Response;
-import com.amcglynn.myenergi.LibbiState;
 import com.amcglynn.myzappi.UserIdResolverFactory;
 import com.amcglynn.myzappi.core.Brand;
 import com.amcglynn.myzappi.core.model.UserId;
@@ -35,19 +34,12 @@ public class GetLibbiEnabledHandler implements RequestHandler {
         var userId = userIdResolverFactory.newUserIdResolver(handlerInput);
         var libbiService = myEnergiServiceBuilder.build(userIdResolverFactory.newUserIdResolver(handlerInput)).getLibbiServiceOrThrow();
         var status = libbiService.getStatus(UserId.from(userId.getUserId()));
-        var stateOfCharge = status.getState();
-
-        if (stateOfCharge == LibbiState.OFF) {
-            return handlerInput.getResponseBuilder()
-                    .withSpeech(voiceResponse(handlerInput, "libbi-disabled"))
-                    .withSimpleCard(Brand.NAME, cardResponse(handlerInput, "libbi-disabled"))
-                    .withShouldEndSession(false)
-                    .build();
-        }
 
         return handlerInput.getResponseBuilder()
-                .withSpeech(voiceResponse(handlerInput, "libbi-enabled"))
-                .withSimpleCard(Brand.NAME, cardResponse(handlerInput, "libbi-enabled"))
+                .withSpeech(voiceResponse(handlerInput, "libbi-state",
+                                Map.of("state", status.getStateDescription())))
+                .withSimpleCard(Brand.NAME, cardResponse(handlerInput, "libbi-state",
+                                Map.of("state", status.getStateDescription())))
                 .withShouldEndSession(false)
                 .build();
     }

--- a/myzappi-alexa-lambda/src/main/resources/card-response.properties
+++ b/myzappi-alexa-lambda/src/main/resources/card-response.properties
@@ -56,6 +56,7 @@ change-eddi-mode=Changing Eddi mode to {eddiMode}. This may take a few minutes.
 unrecognised-mode=Sorry, I don't recognise that mode.
 libbi-state-of-charge=State of charge: {chargePercentage}%
 libbi-charge-target-percentage=Charge Target: {chargeTargetPercentage}%
+libbi-state=State: {state}
 libbi-disabled=Your battery is disabled.
 libbi-enabled=Your battery is enabled.
 libbi-enabling=Enabling your battery, this may take a few minutes.

--- a/myzappi-alexa-lambda/src/main/resources/voice-response.properties
+++ b/myzappi-alexa-lambda/src/main/resources/voice-response.properties
@@ -57,6 +57,7 @@ change-eddi-mode=Changing Eddi mode to {eddiMode}. This may take a few minutes.
 unrecognised-mode=Sorry, I don't recognise that mode.
 libbi-state-of-charge=State of charge is {chargePercentage}%
 libbi-charge-target-percentage=Battery charge target is {chargeTargetPercentage}%.
+libbi-state=Your battery is {state}.
 libbi-disabled=Your battery is disabled.
 libbi-enabled=Your battery is enabled.
 libbi-enabling=Enabling your battery, this may take a few minutes.

--- a/myzappi-alexa-lambda/src/test/java/com/amcglynn/myzappi/handlers/GetLibbiEnabledHandlerTest.java
+++ b/myzappi-alexa-lambda/src/test/java/com/amcglynn/myzappi/handlers/GetLibbiEnabledHandlerTest.java
@@ -70,8 +70,8 @@ class GetLibbiEnabledHandlerTest {
         when(mockLibbiService.getStatus(any())).thenReturn(LibbiStatus.builder().state(LibbiState.ON).build());
         var response = handler.handle(handlerInputBuilder("GetLibbiEnabled").build());
         assertThat(response).isPresent();
-        verifySpeechInResponse(response.get(), "<speak>Your battery is enabled.</speak>");
-        verifySimpleCardInResponse(response.get(), "My Zappi", "Your battery is enabled.");
+        verifySpeechInResponse(response.get(), "<speak>Your battery is On.</speak>");
+        verifySimpleCardInResponse(response.get(), "My Zappi", "State: On");
     }
 
     @Test
@@ -79,7 +79,7 @@ class GetLibbiEnabledHandlerTest {
         when(mockLibbiService.getStatus(any())).thenReturn(LibbiStatus.builder().state(LibbiState.OFF).build());
         var response = handler.handle(handlerInputBuilder("GetLibbiEnabled").build());
         assertThat(response).isPresent();
-        verifySpeechInResponse(response.get(), "<speak>Your battery is disabled.</speak>");
-        verifySimpleCardInResponse(response.get(), "My Zappi", "Your battery is disabled.");
+        verifySpeechInResponse(response.get(), "<speak>Your battery is Off.</speak>");
+        verifySimpleCardInResponse(response.get(), "My Zappi", "State: Off");
     }
 }

--- a/site/myzappi/src/app/libbi-panel/libbi-panel.component.html
+++ b/site/myzappi/src/app/libbi-panel/libbi-panel.component.html
@@ -1,7 +1,7 @@
 <div class="deviceTile">
     <h2><img class="headerIconImage" src="assets/images/batteryFull.png" alt="Battery"> Libbi</h2>
     <div>
-        Enabled: {{libbiEnabled}} <app-inline-schedule-panel [bearerToken]="bearerToken" [serialNumber]="serialNumber" [actionComponentType]="libbiSetEnabledActionPanelComponent"></app-inline-schedule-panel>
+        State: {{libbiState}} <app-inline-schedule-panel [bearerToken]="bearerToken" [serialNumber]="serialNumber" [actionComponentType]="libbiSetEnabledActionPanelComponent"></app-inline-schedule-panel>
     </div>
     <br>
     <div>

--- a/site/myzappi/src/app/libbi-panel/libbi-panel.component.ts
+++ b/site/myzappi/src/app/libbi-panel/libbi-panel.component.ts
@@ -19,6 +19,7 @@ interface SetChargeFromGrid {
 interface LibbiSummary {
   serialNumber: string,
   stateOfChargePercentage: number,
+  stateDescription: string,
   batterySizeKWh: string,
   chargeFromGridEnabled: boolean,
   energyTargetKWh: string;
@@ -48,6 +49,7 @@ export class LibbiPanelComponent {
   energyTargetKWh = '';
   energyTargetPercentage = '';
   libbiEnabled = false;
+  libbiState = '';
 
   mode: any;
   changeModeEnabled = true;
@@ -79,6 +81,7 @@ export class LibbiPanelComponent {
         } else {
           this.libbiEnabled = true;
         }
+        this.libbiState = data.stateDescription;
       });
   }
 


### PR DESCRIPTION
The Website and Alexa skill were returning either enabled/disabled for Libbi. There were reported issues from myenergi forum users that the wrong status was being reported. Disabled was being reported when it was actually enabled but in an unexpected state. 
This was changed to report back a translated state which is a more appropriate representation of the Libbi back to the user.