### PR TITLE
Update device status API to support Eddi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,5 @@
 # Welcome to MyZappi!
-
-Task list:
-Launch screen
-Add QR code: https://s3.eu-west-1.amazonaws.com/www.myzappiunofficial.com/assets/images/qrcode.jpg
-
-SetChargeMode
-1. Prompt the user to confirm if they want to unlock the charge mode if it is locked
-
-Create validation interceptor for slots
-
-Show the energy usage graph as a background image for getting the status. This should be done in a separate thread.
-
-The most popular commands from about 10 months are:
-1. Set charge mode
--- prompt the user to confirm if they want to unlock the charger if it is locked
-
-2. Go green
-3. Set eddi mode to stopped
-4. Charge my car
-5. Set eddi mode to normal
-6. Status summary
-7. Get plug status
-8. Get charge rate - show graph of just the charge rate
-9. Get solar report - show graph of solar generation
-
-These commands should be as good as possible, offering value to the user over the myenergi app
+https://www.myzappiunofficial.com/
 
 ## What is MyZappi?
 MyZappi is an Alexa skill that can be used to control your myenergi Zappi device all through an Amazon Echo or Alexa device.

--- a/api/src/main/java/com/amcglynn/myzappi/api/rest/controller/DevicesController.java
+++ b/api/src/main/java/com/amcglynn/myzappi/api/rest/controller/DevicesController.java
@@ -12,6 +12,7 @@ import com.amcglynn.myzappi.api.rest.request.ZappiChargeModeMapper;
 import com.amcglynn.myzappi.api.rest.response.DeviceDiscoveryResponse;
 import com.amcglynn.myzappi.api.rest.response.DeviceResponse;
 import com.amcglynn.myzappi.api.rest.response.ListDeviceResponse;
+import com.amcglynn.myzappi.api.rest.response.MyEnergiEddiStatusResponse;
 import com.amcglynn.myzappi.api.rest.response.MyEnergiDeviceStatusResponse;
 import com.amcglynn.myzappi.api.service.RegistrationService;
 import com.amcglynn.myzappi.core.model.DeviceClass;
@@ -223,6 +224,13 @@ public class DevicesController {
             return new Response(200, mapper.writeValueAsString(service.getLibbiService()
                     .get()
                     .getStatus(request.getUserId(), serialNumber)));
+        } else if (DeviceClass.EDDI == device.getDeviceClass()) {
+            var status = service.getEddiService()
+                    .get()
+                    .getStatus(serialNumber);
+            return new Response(200, mapper.writeValueAsString(
+                    new MyEnergiEddiStatusResponse(status)
+            ));
         } else {
             throw new ServerException(404);
         }

--- a/api/src/main/java/com/amcglynn/myzappi/api/rest/response/EnergyResponse.java
+++ b/api/src/main/java/com/amcglynn/myzappi/api/rest/response/EnergyResponse.java
@@ -2,6 +2,7 @@ package com.amcglynn.myzappi.api.rest.response;
 
 import com.amcglynn.myenergi.ZappiStatusSummary;
 import com.amcglynn.myenergi.units.KiloWatt;
+import com.amcglynn.myzappi.core.model.EddiStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +20,13 @@ public class EnergyResponse {
     private KiloWatt exportingKW;
 
     public EnergyResponse(ZappiStatusSummary summary) {
+        this.solarGenerationKW = new KiloWatt(summary.getGenerated());
+        this.consumingKW = new KiloWatt(summary.getConsumed());
+        this.importingKW = new KiloWatt(summary.getGridImport());
+        this.exportingKW = new KiloWatt(summary.getGridExport());
+    }
+
+    public EnergyResponse(EddiStatus summary) {
         this.solarGenerationKW = new KiloWatt(summary.getGenerated());
         this.consumingKW = new KiloWatt(summary.getConsumed());
         this.importingKW = new KiloWatt(summary.getGridImport());

--- a/api/src/main/java/com/amcglynn/myzappi/api/rest/response/MyEnergiDeviceStatusResponse.java
+++ b/api/src/main/java/com/amcglynn/myzappi/api/rest/response/MyEnergiDeviceStatusResponse.java
@@ -81,4 +81,12 @@ public class MyEnergiDeviceStatusResponse {
         this.chargeStatus = summary.getChargeStatus();
         this.lockStatus = summary.getLockStatus();
     }
+
+    protected MyEnergiDeviceStatusResponse(DeviceType deviceType,
+            SerialNumber serialNumber,
+            EnergyResponse energyResponse) {
+        this.type = deviceType;
+        this.serialNumber = serialNumber;
+        this.energy = energyResponse;
+    }
 }

--- a/api/src/main/java/com/amcglynn/myzappi/api/rest/response/MyEnergiDeviceStatusResponse.java
+++ b/api/src/main/java/com/amcglynn/myzappi/api/rest/response/MyEnergiDeviceStatusResponse.java
@@ -81,12 +81,4 @@ public class MyEnergiDeviceStatusResponse {
         this.chargeStatus = summary.getChargeStatus();
         this.lockStatus = summary.getLockStatus();
     }
-
-    protected MyEnergiDeviceStatusResponse(DeviceType deviceType,
-            SerialNumber serialNumber,
-            EnergyResponse energyResponse) {
-        this.type = deviceType;
-        this.serialNumber = serialNumber;
-        this.energy = energyResponse;
-    }
 }

--- a/api/src/main/java/com/amcglynn/myzappi/api/rest/response/MyEnergiEddiStatusResponse.java
+++ b/api/src/main/java/com/amcglynn/myzappi/api/rest/response/MyEnergiEddiStatusResponse.java
@@ -1,0 +1,38 @@
+package com.amcglynn.myzappi.api.rest.response;
+
+import com.amcglynn.myenergi.EddiState;
+import com.amcglynn.myenergi.units.KiloWattHour;
+import com.amcglynn.myzappi.core.model.EddiStatus;
+import com.amcglynn.myzappi.core.model.SerialNumber;
+import com.amcglynn.myzappi.core.model.SerialNumberDeserializer;
+import com.amcglynn.myzappi.core.model.SerialNumberSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class MyEnergiEddiStatusResponse {
+
+    @JsonDeserialize(using = SerialNumberDeserializer.class)
+    @JsonSerialize(using = SerialNumberSerializer.class)
+    private SerialNumber serialNumber;
+    private DeviceType type;
+    private EnergyResponse energy;
+
+    private EddiState state;
+    private String activeHeater;
+    private KiloWattHour consumedThisSessionKWh;
+
+    public MyEnergiEddiStatusResponse(EddiStatus summary) {
+        this.type = DeviceType.EDDI;
+        this.serialNumber = summary.getSerialNumber();
+        this.energy = new EnergyResponse(summary);
+        this.state = summary.getState();
+        this.activeHeater = summary.getActiveHeater();
+        this.consumedThisSessionKWh = summary.getConsumedThisSessionKWh();
+    }
+}

--- a/core/src/main/java/com/amcglynn/myzappi/core/model/EddiStatus.java
+++ b/core/src/main/java/com/amcglynn/myzappi/core/model/EddiStatus.java
@@ -1,0 +1,31 @@
+package com.amcglynn.myzappi.core.model;
+
+import com.amcglynn.myenergi.EddiState;
+import com.amcglynn.myenergi.units.KiloWattHour;
+import com.amcglynn.myenergi.units.Watt;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EddiStatus {
+    @JsonDeserialize(using = SerialNumberDeserializer.class)
+    @JsonSerialize(using = SerialNumberSerializer.class)
+    private SerialNumber serialNumber;
+    private EddiState state;
+    private String activeHeater;
+    private Watt gridImport;
+    private Watt gridExport;
+    private Watt consumed;
+    private Watt generated;
+
+    private KiloWattHour consumedThisSessionKWh;
+}

--- a/core/src/main/java/com/amcglynn/myzappi/core/service/EddiService.java
+++ b/core/src/main/java/com/amcglynn/myzappi/core/service/EddiService.java
@@ -1,7 +1,12 @@
 package com.amcglynn.myzappi.core.service;
 
 import com.amcglynn.myenergi.EddiMode;
+import com.amcglynn.myenergi.EddiState;
 import com.amcglynn.myenergi.MyEnergiClient;
+import com.amcglynn.myenergi.units.KiloWattHour;
+import com.amcglynn.myenergi.units.Watt;
+import com.amcglynn.myzappi.core.model.EddiStatus;
+import com.amcglynn.myzappi.core.model.SerialNumber;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
@@ -9,7 +14,7 @@ import java.time.Duration;
 @Slf4j
 public class EddiService {
 
-    private MyEnergiClient client;
+    private final MyEnergiClient client;
 
     public EddiService(MyEnergiClient client) {
         this.client = client;
@@ -43,5 +48,22 @@ public class EddiService {
             log.info("Invalid heater number {}", heaterNumber);
             throw new IllegalArgumentException("Invalid heater number");
         }
+    }
+
+    public EddiStatus getStatus(SerialNumber serialNumber) {
+        var response = client.getEddiStatus(serialNumber.toString()).getEddi().getFirst();
+        var gridImport = new Watt(Math.max(0, response.getGridWatts()));
+        var gridExport = new Watt(Math.abs(Math.min(0, response.getGridWatts())));
+        var generated = new Watt(response.getSolarGeneration());
+        return EddiStatus.builder()
+                .serialNumber(serialNumber)
+                .activeHeater(response.getActiveHeater() == 1 ? response.getTank1Name() : response.getTank2Name())
+                .state(EddiState.fromCode(response.getStatus()))
+                .consumed(new Watt(generated).add(gridImport).subtract(gridExport))
+                .consumedThisSessionKWh(new KiloWattHour((double) response.getEnergyTransferred() / 1000))
+                .generated(generated)
+                .gridExport(gridExport)
+                .gridImport(gridImport)
+                .build();
     }
 }

--- a/myenergi-client/src/main/java/com/amcglynn/myenergi/EddiState.java
+++ b/myenergi-client/src/main/java/com/amcglynn/myenergi/EddiState.java
@@ -1,0 +1,36 @@
+package com.amcglynn.myenergi;
+
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public enum EddiState {
+    PAUSED(1, "Paused"),
+    DIVERTING(3, "Diverting"),
+    BOOST(4, "Boost"),
+    MAX_TEMP_REACHED(5, "Max Temp Reached"),
+    STOPPED(6, "Stopped");
+
+    private final int code;
+    private final String description;
+
+    private static final Map<Integer, EddiState> CODE_MAP = new HashMap<>();
+
+    static {
+        for (EddiState state : values()) {
+            CODE_MAP.put(state.code, state);
+        }
+    }
+
+    EddiState(int code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public static EddiState fromCode(int code) {
+        return CODE_MAP.get(code);
+    }
+}
+

--- a/myenergi-client/src/main/java/com/amcglynn/myenergi/MockMyEnergiClient.java
+++ b/myenergi-client/src/main/java/com/amcglynn/myenergi/MockMyEnergiClient.java
@@ -1,6 +1,11 @@
 package com.amcglynn.myenergi;
 
-import com.amcglynn.myenergi.apiresponse.*;
+import com.amcglynn.myenergi.apiresponse.LibbiStatusResponse;
+import com.amcglynn.myenergi.apiresponse.StatusResponse;
+import com.amcglynn.myenergi.apiresponse.ZappiDayHistory;
+import com.amcglynn.myenergi.apiresponse.ZappiHourlyDayHistory;
+import com.amcglynn.myenergi.apiresponse.ZappiStatusResponse;
+import com.amcglynn.myenergi.apiresponse.EddiStatusResponse;
 import com.amcglynn.myenergi.units.KiloWattHour;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -19,7 +24,7 @@ import java.util.List;
  */
 public class MockMyEnergiClient extends MyEnergiClient {
 
-    private static MockWebServer mockWebServer = new MockWebServer();
+    private static final MockWebServer mockWebServer = new MockWebServer();
     private static final String HUB_SERIAL_NUMBER = "12345678";
     private static final String API_KEY = "myDemoApiKey";
 

--- a/myenergi-client/src/main/java/com/amcglynn/myenergi/MockMyEnergiClient.java
+++ b/myenergi-client/src/main/java/com/amcglynn/myenergi/MockMyEnergiClient.java
@@ -1,10 +1,6 @@
 package com.amcglynn.myenergi;
 
-import com.amcglynn.myenergi.apiresponse.LibbiStatusResponse;
-import com.amcglynn.myenergi.apiresponse.StatusResponse;
-import com.amcglynn.myenergi.apiresponse.ZappiDayHistory;
-import com.amcglynn.myenergi.apiresponse.ZappiHourlyDayHistory;
-import com.amcglynn.myenergi.apiresponse.ZappiStatusResponse;
+import com.amcglynn.myenergi.apiresponse.*;
 import com.amcglynn.myenergi.units.KiloWattHour;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -59,6 +55,16 @@ public class MockMyEnergiClient extends MyEnergiClient {
                 .setBody(MockMyEnergiResponses.getExampleResponse(zappiSerialNumber));
         mockWebServer.enqueue(mockResponse);
         return super.getZappiStatus(zappiSerialNumber);
+    }
+
+    @Override
+    public EddiStatusResponse getEddiStatus(String eddiSerialNumber) {
+        var mockResponse = new MockResponse()
+                .setResponseCode(200)
+                .addHeader("x_myenergi-asn", mockWebServer.url("").uri())
+                .setBody(MockMyEnergiResponses.getExampleJStatusResponseWithEddi());
+        mockWebServer.enqueue(mockResponse);
+        return super.getEddiStatus(eddiSerialNumber);
     }
 
     @Override

--- a/myenergi-client/src/main/java/com/amcglynn/myenergi/MockMyEnergiResponses.java
+++ b/myenergi-client/src/main/java/com/amcglynn/myenergi/MockMyEnergiResponses.java
@@ -246,6 +246,60 @@ public class MockMyEnergiResponses {
                 """, EDDI_SERIAL_NUMBER_1, LIBBI_SERIAL_NUMBER_1, ZAPPI_SERIAL_NUMBER_1, ZAPPI_SERIAL_NUMBER_2);
     }
 
+    public static String getExampleJStatusResponseWithEddi() {
+        return String.format(""" 
+                {
+                    "eddi": [
+                        {
+                            "deviceClass": "EDDI",
+                            "sno": %s,
+                            "dat": "10-05-2024",
+                            "tim": "15:19:32",
+                            "ectp1": 4,
+                            "ectp2": 0,
+                            "ectp3": 0,
+                            "ectt1": "Internal Load",
+                            "ectt2": "None",
+                            "ectt3": "None",
+                            "bsm": 0,
+                            "bst": 0,
+                            "dst": 1,
+                            "div": 4,
+                            "frq": 50.02,
+                            "gen": 2723,
+                            "grd": -76,
+                            "pha": 1,
+                            "pri": 3,
+                            "sta": 1,
+                            "tz": 0,
+                            "vol": 2443,
+                            "che": 0,
+                            "isVHubEnabled": false,
+                            "hpri": 1,
+                            "hno": 1,
+                            "ht1": "Tank 1",
+                            "ht2": "Tank 2",
+                            "r1a": 0,
+                            "r2a": 0,
+                            "r1b": 0,
+                            "r2b": 0,
+                            "rbc": 1,
+                            "tp1": 42,
+                            "tp2": 41,
+                            "che": 4321,
+                            "batteryDischargeEnabled": false,
+                            "g100LockoutState": "NONE",
+                            "cmt": 254,
+                            "fwv": "3202S5.408",
+                            "newAppAvailable": false,
+                            "newBootloaderAvailable": false,
+                            "productCode": "3202"
+                        }
+                    ]
+                }
+                """, EDDI_SERIAL_NUMBER_1);
+    }
+
     public static String getExampleResponse() {
         return getExampleResponse(ZAPPI_SERIAL_NUMBER_1);
     }

--- a/myenergi-client/src/main/java/com/amcglynn/myenergi/MyEnergiClient.java
+++ b/myenergi-client/src/main/java/com/amcglynn/myenergi/MyEnergiClient.java
@@ -16,6 +16,7 @@ import com.amcglynn.myenergi.apiresponse.StatusResponse;
 import com.amcglynn.myenergi.apiresponse.ZappiDayHistory;
 import com.amcglynn.myenergi.apiresponse.ZappiHourlyDayHistory;
 import com.amcglynn.myenergi.apiresponse.ZappiStatusResponse;
+import com.amcglynn.myenergi.apiresponse.EddiStatusResponse;
 import com.amcglynn.myenergi.exception.ClientException;
 import com.amcglynn.myenergi.exception.InvalidRequestException;
 import com.amcglynn.myenergi.exception.InvalidResponseFormatException;
@@ -102,6 +103,15 @@ public class MyEnergiClient {
 
     public ZappiStatusResponse getZappiStatus(String zappiSerialNumber) {
         var response = getRequest("/cgi-jstatus-Z" + zappiSerialNumber);
+        try {
+            return new ObjectMapper().readValue(response, new TypeReference<>(){});
+        } catch (JsonProcessingException e) {
+            throw new InvalidResponseFormatException();
+        }
+    }
+
+    public EddiStatusResponse getEddiStatus(String eddiSerialNumber) {
+        var response = getRequest("/cgi-jstatus-E" + eddiSerialNumber);
         try {
             return new ObjectMapper().readValue(response, new TypeReference<>(){});
         } catch (JsonProcessingException e) {

--- a/myenergi-client/src/main/java/com/amcglynn/myenergi/apiresponse/EddiStatus.java
+++ b/myenergi-client/src/main/java/com/amcglynn/myenergi/apiresponse/EddiStatus.java
@@ -1,0 +1,95 @@
+package com.amcglynn.myenergi.apiresponse;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Getter
+@Setter
+@NoArgsConstructor
+@Accessors(chain = true)
+public class EddiStatus {
+    @JsonProperty("deviceClass")
+    private String deviceClass = "EDDI";
+    @JsonProperty("sno")
+    private String serialNumber;
+    @JsonProperty("bsm")
+    private int boostMode; // 1 if boosting
+    @JsonProperty("che")
+    private double energyTransferredKwh; // total kWh transferred this session
+    @JsonProperty("div")
+    private long diversionAmountWatts;
+    @JsonProperty("gen")
+    private long solarGenerationWatts;
+    @JsonProperty("grd")
+    private long gridWatts;
+    @JsonProperty("hno")
+    private int activeHeater;
+    @JsonProperty("ht1")
+    private String tank1Name;
+    @JsonProperty("ht2")
+    private String tank2Name;
+    @JsonProperty("sta")
+    private int status; // 1=Paused, 3=Diverting, 4=Boost, 5=Max Temp Reached, 6=Stopped
+
+    public EddiStatus(String serialNumber, int status) {
+        this.serialNumber = serialNumber;
+        this.status = status;
+    }
+
+    public static EddiStatusBuilder builder() {
+        return new EddiStatusBuilder();
+    }
+
+    public static class EddiStatusBuilder {
+        private final EddiStatus eddiStatus = new EddiStatus();
+
+        public EddiStatusBuilder serialNumber(String serialNumber) {
+            eddiStatus.setSerialNumber(serialNumber);
+            return this;
+        }
+        public EddiStatusBuilder boostMode(int boostMode) {
+            eddiStatus.setBoostMode(boostMode);
+            return this;
+        }
+        public EddiStatusBuilder energyTransferredKwh(double energyTransferredKwh) {
+            eddiStatus.setEnergyTransferredKwh(energyTransferredKwh);
+            return this;
+        }
+        public EddiStatusBuilder diversionAmountWatts(long diversionAmountWatts) {
+            eddiStatus.setDiversionAmountWatts(diversionAmountWatts);
+            return this;
+        }
+        public EddiStatusBuilder generatedWatts(long generatedWatts) {
+            eddiStatus.setSolarGenerationWatts(generatedWatts);
+            return this;
+        }
+        public EddiStatusBuilder gridWatts(long gridWatts) {
+            eddiStatus.setGridWatts(gridWatts);
+            return this;
+        }
+        public EddiStatusBuilder activeHeater(int activeHeater) {
+            eddiStatus.setActiveHeater(activeHeater);
+            return this;
+        }
+        public EddiStatusBuilder tank1Name(String tank1Name) {
+            eddiStatus.setTank1Name(tank1Name);
+            return this;
+        }
+        public EddiStatusBuilder tank2Name(String tank2Name) {
+            eddiStatus.setTank2Name(tank2Name);
+            return this;
+        }
+        public EddiStatusBuilder status(int status) {
+            eddiStatus.setStatus(status);
+            return this;
+        }
+        public EddiStatus build() {
+            return eddiStatus;
+        }
+    }
+}

--- a/myenergi-client/src/main/java/com/amcglynn/myenergi/apiresponse/EddiStatusResponse.java
+++ b/myenergi-client/src/main/java/com/amcglynn/myenergi/apiresponse/EddiStatusResponse.java
@@ -1,0 +1,17 @@
+package com.amcglynn.myenergi.apiresponse;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EddiStatusResponse {
+    private List<MyEnergiDeviceStatus> eddi = new ArrayList<>();
+}

--- a/myenergi-client/src/main/java/com/amcglynn/myenergi/apiresponse/MyEnergiDeviceStatus.java
+++ b/myenergi-client/src/main/java/com/amcglynn/myenergi/apiresponse/MyEnergiDeviceStatus.java
@@ -20,6 +20,15 @@ public class MyEnergiDeviceStatus {
     @JsonProperty("gen")
     private Long solarGeneration = 0L;
 
+    @JsonProperty("hno")
+    private int activeHeater = 1;
+
+    @JsonProperty("che")
+    private Long energyTransferred = 0L;
+
+    @JsonProperty("sta")
+    private int status = 1; // 1=Paused, 3=Diverting, 4=Boost, 5=Max Temp Reached, 6=Stopped
+
 //    {
 //        "zappi": [
 //        {

--- a/myenergi-client/src/test/java/com/amcglynn/myenergi/MyEnergiClientTest.java
+++ b/myenergi-client/src/test/java/com/amcglynn/myenergi/MyEnergiClientTest.java
@@ -201,6 +201,21 @@ class MyEnergiClientTest {
     }
 
     @Test
+    void testGetEddiStatus() {
+        var mockResponse = new MockResponse()
+                .setResponseCode(200)
+                .setBody(MockMyEnergiResponses.getExampleJStatusResponseWithEddi()
+                        );
+        mockWebServer.enqueue(mockResponse);
+
+        var response = client.getEddiStatus("20000001");
+
+        assertThat(response.getEddi()).hasSize(1);
+        var eddiResponse = response.getEddi().get(0);
+        assertThat(eddiResponse.getSerialNumber()).isEqualTo("20000001");
+    }
+
+    @Test
     void testBoostModeThrowsInvalidRequestExceptionWhenMinuteIsNotDivisibleBy15() {
         var mockResponse = new MockResponse()
                 .setResponseCode(200)


### PR DESCRIPTION
Updated device status API to fetch Eddi status
```
GET https://api.myzappiunofficial.com/devices/20000001/status
```

Example response
```
{
    "serialNumber": "20000001",
    "type": "eddi",
    "energy": {
        "solarGenerationKW": "2.7",
        "consumingKW": "2.6",
        "importingKW": "0.0",
        "exportingKW": "0.1"
    },
    "state": "PAUSED",
    "activeHeater": "Tank 1",
    "consumedThisSessionKWh": "4.3"
}
```